### PR TITLE
Update the indent of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build run
 
 build:
-  cargo osdk build --target-arch riscv64
+		cargo osdk build --target-arch riscv64
 
 run:
-  cargo osdk run --target-arch riscv64
+		cargo osdk run --target-arch riscv64


### PR DESCRIPTION
I don't know why, but the original indentation of Makefile seems to have problem:

```
$ make
Makefile:4: *** missing separator.  Stop.
```

After changing the indentation, problem solved.